### PR TITLE
Arch/Void install scripts

### DIFF
--- a/other_distros/arch.sh
+++ b/other_distros/arch.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+sudo pacman -S wget erlang erlang-wx --noconfirm
+
+wget -q https://zxq9.com/projects/zomp/get_zx && bash get_zx
+export PATH=$PATH:$HOME/bin
+
+zx import realm install_scripts/qpq.zrf
+zx import realm install_scripts/uwiger.zrf
+zx run qpq-gajumine

--- a/other_distros/debian.sh
+++ b/other_distros/debian.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+sudo apt -y install wget erlang --no-install-recommends
+
+wget -q https://zxq9.com/projects/zomp/get_zx && bash get_zx
+export PATH=$PATH:$HOME/bin
+
+zx import realm install_scripts/qpq.zrf
+zx import realm install_scripts/uwiger.zrf
+zx run qpq-gajumine

--- a/other_distros/debian_kerl.sh
+++ b/other_distros/debian_kerl.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+sudo apt update
+sudo apt upgrade
+sudo apt -y install \
+    gcc curl g++ dpkg-dev build-essential automake autoconf \
+    libncurses-dev libssl-dev flex xsltproc libwxgtk3.2-dev \
+    wget vim git
+
+curl -O https://raw.githubusercontent.com/kerl/kerl/master/kerl
+chmod a+x kerl
+./kerl build 27.3.4 27.3.4
+./kerl install 27.3.4 ~/.erts/27.3.4
+echo '. "$HOME"/.erts/27.3.4/activate' >> .bashrc
+. ~/.erts/27.3.4/activate
+
+wget -q https://zxq9.com/projects/zomp/get_zx && bash get_zx
+export PATH=$PATH:$HOME/bin
+
+zx import realm ~/install_scripts/qpq.zrf
+zx import realm ~/install_scripts/uwiger.zrf
+zx run qpq-gajumine

--- a/other_distros/void_kerl.sh
+++ b/other_distros/void_kerl.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+sudo xbps-install -y curl wget git gcc autoconf make libxslt noto-fonts-ttf \
+    wxWidgets-gtk3-devel openssl-devel ncurses-devel glu-devel
+
+mkdir ~/bin
+ln -s /usr/bin/wx-config-gtk3 ~/bin/wx-config
+export PATH=$PATH:$HOME/bin
+
+curl -O https://raw.githubusercontent.com/kerl/kerl/master/kerl
+chmod a+x kerl
+./kerl build 27.3.4 27.3.4
+./kerl install 27.3.4 ~/.erts/27.3.4
+echo '. "$HOME"/.erts/27.3.4/activate' >> .bashrc
+. ~/.erts/27.3.4/activate
+
+wget -q https://zxq9.com/projects/zomp/get_zx && bash get_zx
+
+zx import realm ~/install_scripts/qpq.zrf
+zx import realm ~/install_scripts/uwiger.zrf
+zx run qpq-gajumine


### PR DESCRIPTION
These scripts were all tested in https://git.qpq.swiss/QPQ-AG/chroot_sandboxes and represent the minimal dependencies needed to open the mining GUI. They don't create any desktop icons, making for a more light-weight install process for users who are happy to work from the command line. They also don't set up any services to automatically run a headless miner, although the commands that do this on ubuntu should also work on other SystemD computers like Debian or Arch, but not Devuan, Artix, or Void.